### PR TITLE
Define CZMQ_EXPORT to ease building

### DIFF
--- a/include/zmtp_dealer.h
+++ b/include/zmtp_dealer.h
@@ -24,7 +24,7 @@ typedef struct _zmtp_dealer_t zmtp_dealer_t;
 //  Constructor; takes ownership of data and frees it when destroying the
 //  message. Nullifies the data reference.
 zmtp_dealer_t *
-    zmtp_dealer_new ();
+    zmtp_dealer_new (void);
 
 void
     zmtp_dealer_destroy (zmtp_dealer_t **self_p);

--- a/include/zmtp_prelude.h
+++ b/include/zmtp_prelude.h
@@ -497,14 +497,14 @@ typedef int SOCKET;
 
 #if defined (__WINDOWS__)
 #   if defined LIBZMTP_STATIC
-#       define ZMTP_EXPORT
+#       define CZMQ_EXPORT
 #   elif defined LIBZMTP_EXPORTS
-#       define ZMTP_EXPORT __declspec(dllexport)
+#       define CZMQ_EXPORT __declspec(dllexport)
 #   else
-#       define ZMTP_EXPORT __declspec(dllimport)
+#       define CZMQ_EXPORT __declspec(dllimport)
 #   endif
 #else
-#   define ZMTP_EXPORT
+#   define CZMQ_EXPORT
 #endif
 
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@ pkgconfig_DATA = libzmtp.pc
 
 include_HEADERS = \
     ../include/zmtp.h \
+    ../include/zmtp_prelude.h \
     ../include/zmtp_msg.h \
     ../include/zmtp_dealer.h
 

--- a/src/zmtp_channel.c
+++ b/src/zmtp_channel.c
@@ -80,10 +80,12 @@ zmtp_channel_ipc_connect (zmtp_channel_t *self, const char *path)
     if (strlen (path) >= sizeof remote.sun_path)
         return -1;
     strcpy (remote.sun_path, path);
+    
     //  Create socket
     const int s = socket (AF_UNIX, SOCK_STREAM, 0);
     if (s == -1)
         return -1;
+    
     //  Connect the socket
     const int rc =
         connect (s, (const struct sockaddr *) &remote, sizeof remote);
@@ -112,10 +114,12 @@ zmtp_channel_tcp_connect (zmtp_channel_t *self,
 
     if (self->fd != -1)
         return -1;
+    
     //  Create socket
     const int s = socket (AF_INET, SOCK_STREAM, 0);
     if (s == -1)
         return -1;
+    
     //  Resolve address
     const struct addrinfo hints = {
         .ai_family   = AF_INET,
@@ -374,30 +378,37 @@ s_echo_serv (void *arg)
     //  Create socket
     const int s = socket (AF_INET, SOCK_STREAM, 0);
     assert (s != -1);
+    
     //  Allow port reuse
     const int on = 1;
     int rc = setsockopt (s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof on);
     assert (rc == 0);
+    
     //  Fill address
     struct sockaddr_in server_addr;
     server_addr.sin_family = AF_INET;
     server_addr.sin_port = htons (params->port);
     server_addr.sin_addr.s_addr = htonl (INADDR_ANY);
+    
     //  Bind socket
     rc = bind (s, (struct sockaddr *) &server_addr, sizeof server_addr);
     assert (rc == 0);
+    
     //  Listen for connections
     rc = listen (s, 1);
     assert (rc != -1);
+    
     //  Accept connection
     int fd = accept (s, NULL, NULL);
     assert (fd != -1);
+    
     //  Set non-blocking mode
     const int flags = fcntl (fd, F_GETFL, 0);
     assert (flags != -1);
     rc = fcntl (fd, F_SETFL, flags | O_NONBLOCK);
     assert (rc == 0);
     unsigned char buf [80];
+    
     //  Echo all received data
     while (1) {
         struct pollfd pollfd;
@@ -503,7 +514,9 @@ zmtp_channel_test (bool verbose)
         "22",
         "333",
         "4444",
-        "55555"};
+        "55555"
+    };
+        
     for (int i = 0; i < 5; i++) {
         zmtp_msg_t *msg = zmtp_msg_from_const_data (
             0, test_strings [i], strlen (test_strings [i]));

--- a/src/zmtp_dealer.c
+++ b/src/zmtp_dealer.c
@@ -56,18 +56,20 @@ zmtp_dealer_destroy (zmtp_dealer_t **self_p)
 int
 zmtp_dealer_ipc_connect (zmtp_dealer_t *self, const char *path)
 {
-    if (!self)
-        return -1;
+    assert (self);
     if (self->channel)  //  At most one channel per socket now
         return -1;
-    zmtp_channel_t *channel = zmtp_channel_new ();
-    if (!channel)
-        return -1;
-    if (zmtp_channel_ipc_connect (channel, path) == -1) {
-        zmtp_channel_destroy (&channel);
+
+    //  Create new channel if possible
+    self->channel = zmtp_channel_new ();
+    if (!self->channel)
+        return -1;   
+
+    //  Try to connect channel to specified endpoint
+    if (zmtp_channel_ipc_connect (self->channel, path) == -1) {
+        zmtp_channel_destroy (&self->channel);
         return -1;
     }
-    self->channel = channel;
     return 0;
 }
 
@@ -79,18 +81,20 @@ int
 zmtp_dealer_tcp_connect (zmtp_dealer_t *self,
                          const char *addr, unsigned short port)
 {
-    if (!self)
-        return -1;
+    assert (self);
     if (self->channel)  //  At most one channel per socket now
         return -1;
-    zmtp_channel_t *channel = zmtp_channel_new ();
-    if (!channel)
+    
+    //  Create new channel if possible
+    self->channel = zmtp_channel_new ();
+    if (!self->channel)
         return -1;
-    if (zmtp_channel_tcp_connect (channel, addr, port) == -1) {
-        zmtp_channel_destroy (&channel);
+    
+    //  Try to connect channel to specified endpoint
+    if (zmtp_channel_tcp_connect (self->channel, addr, port) == -1) {
+        zmtp_channel_destroy (&self->channel);
         return -1;
     }
-    self->channel = channel;
     return 0;
 }
 
@@ -101,10 +105,10 @@ zmtp_dealer_tcp_connect (zmtp_dealer_t *self,
 int
 zmtp_dealer_send (zmtp_dealer_t *self, zmtp_msg_t *msg)
 {
-    if (!self)
-        return -1;
+    assert (self);
     if (!self->channel)
         return -1;
+    
     return zmtp_channel_send (self->channel, msg);
 }
 
@@ -115,10 +119,10 @@ zmtp_dealer_send (zmtp_dealer_t *self, zmtp_msg_t *msg)
 zmtp_msg_t *
 zmtp_dealer_recv (zmtp_dealer_t *self)
 {
-    if (!self)
-        return NULL;
+    assert (self);
     if (!self->channel)
         return NULL;
+    
     return zmtp_channel_recv (self->channel);
 }
 


### PR DESCRIPTION
Some existing code that has no other CZMQ dependencies still uses
this macro for its API; defining it is helpful.

Also installs zmtp_prelude.h into incdir.
