### PR TITLE
Fix pkg-config template

### DIFF
--- a/src/libzmtp.pc.in
+++ b/src/libzmtp.pc.in
@@ -2,10 +2,8 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-
-Name: libproto
+Name: libzmtp
 Description: a C implementation of UnifyProject/draft/RFC-4
 Version: @VERSION@
-Requires: libzmq libczmq libzyre
-Libs: -L${libdir} -lproto
+Libs: -L${libdir} -lzmtp
 Cflags: -I${includedir}


### PR DESCRIPTION
wrong library name and -l option.  In addition, removed the requirements
for zerovm libraries, as they are not strictly required for building or
consuming libzmtp.
